### PR TITLE
Make 'bytes' a local variable

### DIFF
--- a/lib/resty/fernet.lua
+++ b/lib/resty/fernet.lua
@@ -32,7 +32,7 @@ local function pack_int(int, n)
     return string.char(0):rep(n)
   end
 
-  bytes = ""
+  local bytes = ""
   for i = n * 6, 0, -8 do
     bytes = bytes .. string.char(bit.rshift(int, i) % 256)
   end


### PR DESCRIPTION
OpenResty is logging a warning about `bytes` being a global variable.  This PR makes it a local variable.

```
2020/08/31 16:54:09 [warn] 11003#11003: *30 [lua] _G write guard:12: __newindex(): writing a global Lua variable ('bytes') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables
stack traceback:
	/usr/share/lua/5.1/resty/fernet.lua:35: in function 'pack_int'
	/usr/share/lua/5.1/resty/fernet.lua:98: in function 'encrypt_payload'
```